### PR TITLE
Fixed typo in the dependencies

### DIFF
--- a/src/jAudioFeatureExtractor/AudioFeatures/AreaPolynomialApproximationConstantQMFCC.java
+++ b/src/jAudioFeatureExtractor/AudioFeatures/AreaPolynomialApproximationConstantQMFCC.java
@@ -46,7 +46,7 @@ public class AreaPolynomialApproximationConstantQMFCC extends FeatureExtractor {
 				
 		dependencies = new String[windowLength];
 		for (int i = 0; i < dependencies.length; ++i) {
-			dependencies[i] = "ConstantQ-derived MFCC";
+			dependencies[i] = "ConstantQ derived MFCCs";
 		}
 		
 		offsets = new int[windowLength];

--- a/src/jAudioFeatureExtractor/AudioFeatures/HarmonicSpectralCentroid.java
+++ b/src/jAudioFeatureExtractor/AudioFeatures/HarmonicSpectralCentroid.java
@@ -77,6 +77,8 @@ public class HarmonicSpectralCentroid extends FeatureExtractor {
 			total += peaks[i];
 		}
 		result[0] = weightedTotal / total;
+		//avoid NaN for windows without peaks
+		if(total == 0) result[0] = 0;
 		return result;
 	}
 


### PR DESCRIPTION
The typo led to an exception in the FeatureProcessor.java:525 ("A feature has a spelling error in its dependency.").
