### PR TITLE
Fix CERN Colt-related compilation errors.

### DIFF
--- a/src/cern/clhep/PhysicalConstants.java
+++ b/src/cern/clhep/PhysicalConstants.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/clhep/Units.java
+++ b/src/cern/clhep/Units.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Arrays.java
+++ b/src/cern/colt/Arrays.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/GenericPermuting.java
+++ b/src/cern/colt/GenericPermuting.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/GenericPermuting.java
+++ b/src/cern/colt/GenericPermuting.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/GenericSorting.java
+++ b/src/cern/colt/GenericSorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/GenericSorting.java
+++ b/src/cern/colt/GenericSorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/GenericSortingTest.java
+++ b/src/cern/colt/GenericSortingTest.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Partitioning.java
+++ b/src/cern/colt/Partitioning.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Partitioning.java
+++ b/src/cern/colt/Partitioning.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/PersistentObject.java
+++ b/src/cern/colt/PersistentObject.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Sorting.java
+++ b/src/cern/colt/Sorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Sorting.java
+++ b/src/cern/colt/Sorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Swapper.java
+++ b/src/cern/colt/Swapper.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Timer.java
+++ b/src/cern/colt/Timer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Version.java
+++ b/src/cern/colt/Version.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/Version.java
+++ b/src/cern/colt/Version.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/bitvector/BitMatrix.java
+++ b/src/cern/colt/bitvector/BitMatrix.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/bitvector/BitVector.java
+++ b/src/cern/colt/bitvector/BitVector.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/bitvector/QuickBitVector.java
+++ b/src/cern/colt/bitvector/QuickBitVector.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/DoubleBuffer.java
+++ b/src/cern/colt/buffer/DoubleBuffer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/DoubleBuffer2D.java
+++ b/src/cern/colt/buffer/DoubleBuffer2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/DoubleBuffer2DConsumer.java
+++ b/src/cern/colt/buffer/DoubleBuffer2DConsumer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/DoubleBuffer3D.java
+++ b/src/cern/colt/buffer/DoubleBuffer3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/DoubleBuffer3DConsumer.java
+++ b/src/cern/colt/buffer/DoubleBuffer3DConsumer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/DoubleBufferConsumer.java
+++ b/src/cern/colt/buffer/DoubleBufferConsumer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/IntBuffer.java
+++ b/src/cern/colt/buffer/IntBuffer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/IntBuffer2D.java
+++ b/src/cern/colt/buffer/IntBuffer2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/IntBuffer2DConsumer.java
+++ b/src/cern/colt/buffer/IntBuffer2DConsumer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/IntBuffer3D.java
+++ b/src/cern/colt/buffer/IntBuffer3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/IntBuffer3DConsumer.java
+++ b/src/cern/colt/buffer/IntBuffer3DConsumer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/IntBufferConsumer.java
+++ b/src/cern/colt/buffer/IntBufferConsumer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/ObjectBuffer.java
+++ b/src/cern/colt/buffer/ObjectBuffer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/buffer/ObjectBufferConsumer.java
+++ b/src/cern/colt/buffer/ObjectBufferConsumer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/BooleanProcedure.java
+++ b/src/cern/colt/function/BooleanProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/ByteComparator.java
+++ b/src/cern/colt/function/ByteComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/ByteProcedure.java
+++ b/src/cern/colt/function/ByteProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/CharComparator.java
+++ b/src/cern/colt/function/CharComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/CharProcedure.java
+++ b/src/cern/colt/function/CharProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/Double27Function.java
+++ b/src/cern/colt/function/Double27Function.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/Double5Function.java
+++ b/src/cern/colt/function/Double5Function.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/Double9Function.java
+++ b/src/cern/colt/function/Double9Function.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/DoubleComparator.java
+++ b/src/cern/colt/function/DoubleComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/DoubleDoubleFunction.java
+++ b/src/cern/colt/function/DoubleDoubleFunction.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/DoubleDoubleProcedure.java
+++ b/src/cern/colt/function/DoubleDoubleProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/DoubleFunction.java
+++ b/src/cern/colt/function/DoubleFunction.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/DoubleIntProcedure.java
+++ b/src/cern/colt/function/DoubleIntProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/DoubleProcedure.java
+++ b/src/cern/colt/function/DoubleProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/FloatComparator.java
+++ b/src/cern/colt/function/FloatComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/FloatProcedure.java
+++ b/src/cern/colt/function/FloatProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntComparator.java
+++ b/src/cern/colt/function/IntComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntDoubleFunction.java
+++ b/src/cern/colt/function/IntDoubleFunction.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntDoubleProcedure.java
+++ b/src/cern/colt/function/IntDoubleProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntFunction.java
+++ b/src/cern/colt/function/IntFunction.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntIntDoubleFunction.java
+++ b/src/cern/colt/function/IntIntDoubleFunction.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntIntDoubleProcedure.java
+++ b/src/cern/colt/function/IntIntDoubleProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntIntFunction.java
+++ b/src/cern/colt/function/IntIntFunction.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntIntIntProcedure.java
+++ b/src/cern/colt/function/IntIntIntProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntIntProcedure.java
+++ b/src/cern/colt/function/IntIntProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntObjectProcedure.java
+++ b/src/cern/colt/function/IntObjectProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/IntProcedure.java
+++ b/src/cern/colt/function/IntProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/LongComparator.java
+++ b/src/cern/colt/function/LongComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/LongObjectProcedure.java
+++ b/src/cern/colt/function/LongObjectProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/LongProcedure.java
+++ b/src/cern/colt/function/LongProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/ObjectFunction.java
+++ b/src/cern/colt/function/ObjectFunction.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/ObjectObjectFunction.java
+++ b/src/cern/colt/function/ObjectObjectFunction.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/ObjectProcedure.java
+++ b/src/cern/colt/function/ObjectProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/ShortComparator.java
+++ b/src/cern/colt/function/ShortComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/function/ShortProcedure.java
+++ b/src/cern/colt/function/ShortProcedure.java
@@ -1,7 +1,7 @@
 package cern.colt.function;
 
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractBooleanList.java
+++ b/src/cern/colt/list/AbstractBooleanList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractBooleanList.java
+++ b/src/cern/colt/list/AbstractBooleanList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractByteList.java
+++ b/src/cern/colt/list/AbstractByteList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractByteList.java
+++ b/src/cern/colt/list/AbstractByteList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractCharList.java
+++ b/src/cern/colt/list/AbstractCharList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractCharList.java
+++ b/src/cern/colt/list/AbstractCharList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractCollection.java
+++ b/src/cern/colt/list/AbstractCollection.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractDoubleList.java
+++ b/src/cern/colt/list/AbstractDoubleList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractDoubleList.java
+++ b/src/cern/colt/list/AbstractDoubleList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractFloatList.java
+++ b/src/cern/colt/list/AbstractFloatList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractFloatList.java
+++ b/src/cern/colt/list/AbstractFloatList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractIntList.java
+++ b/src/cern/colt/list/AbstractIntList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractIntList.java
+++ b/src/cern/colt/list/AbstractIntList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractList.java
+++ b/src/cern/colt/list/AbstractList.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractLongList.java
+++ b/src/cern/colt/list/AbstractLongList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractLongList.java
+++ b/src/cern/colt/list/AbstractLongList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractShortList.java
+++ b/src/cern/colt/list/AbstractShortList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/AbstractShortList.java
+++ b/src/cern/colt/list/AbstractShortList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/BooleanArrayList.java
+++ b/src/cern/colt/list/BooleanArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/BooleanArrayList.java
+++ b/src/cern/colt/list/BooleanArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/ByteArrayList.java
+++ b/src/cern/colt/list/ByteArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/ByteArrayList.java
+++ b/src/cern/colt/list/ByteArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/CharArrayList.java
+++ b/src/cern/colt/list/CharArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/CharArrayList.java
+++ b/src/cern/colt/list/CharArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/DistinctNumberList.java
+++ b/src/cern/colt/list/DistinctNumberList.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/DoubleArrayList.java
+++ b/src/cern/colt/list/DoubleArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/DoubleArrayList.java
+++ b/src/cern/colt/list/DoubleArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/FloatArrayList.java
+++ b/src/cern/colt/list/FloatArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/FloatArrayList.java
+++ b/src/cern/colt/list/FloatArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/IntArrayList.java
+++ b/src/cern/colt/list/IntArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/IntArrayList.java
+++ b/src/cern/colt/list/IntArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/LongArrayList.java
+++ b/src/cern/colt/list/LongArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/LongArrayList.java
+++ b/src/cern/colt/list/LongArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/MinMaxNumberList.java
+++ b/src/cern/colt/list/MinMaxNumberList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/MinMaxNumberList.java
+++ b/src/cern/colt/list/MinMaxNumberList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/ObjectArrayList.java
+++ b/src/cern/colt/list/ObjectArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/ObjectArrayList.java
+++ b/src/cern/colt/list/ObjectArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/ShortArrayList.java
+++ b/src/cern/colt/list/ShortArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/ShortArrayList.java
+++ b/src/cern/colt/list/ShortArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/SimpleLongArrayList.java
+++ b/src/cern/colt/list/SimpleLongArrayList.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/DoubleListAdapter.java
+++ b/src/cern/colt/list/adapter/DoubleListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/DoubleListAdapter.java
+++ b/src/cern/colt/list/adapter/DoubleListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/FloatListAdapter.java
+++ b/src/cern/colt/list/adapter/FloatListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/FloatListAdapter.java
+++ b/src/cern/colt/list/adapter/FloatListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/IntListAdapter.java
+++ b/src/cern/colt/list/adapter/IntListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/IntListAdapter.java
+++ b/src/cern/colt/list/adapter/IntListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/LongListAdapter.java
+++ b/src/cern/colt/list/adapter/LongListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/LongListAdapter.java
+++ b/src/cern/colt/list/adapter/LongListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/ObjectListAdapter.java
+++ b/src/cern/colt/list/adapter/ObjectListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/list/adapter/ObjectListAdapter.java
+++ b/src/cern/colt/list/adapter/ObjectListAdapter.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractDoubleIntMap.java
+++ b/src/cern/colt/map/AbstractDoubleIntMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractDoubleIntMap.java
+++ b/src/cern/colt/map/AbstractDoubleIntMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractIntDoubleMap.java
+++ b/src/cern/colt/map/AbstractIntDoubleMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractIntDoubleMap.java
+++ b/src/cern/colt/map/AbstractIntDoubleMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractIntIntMap.java
+++ b/src/cern/colt/map/AbstractIntIntMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractIntIntMap.java
+++ b/src/cern/colt/map/AbstractIntIntMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractIntObjectMap.java
+++ b/src/cern/colt/map/AbstractIntObjectMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractIntObjectMap.java
+++ b/src/cern/colt/map/AbstractIntObjectMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractLongObjectMap.java
+++ b/src/cern/colt/map/AbstractLongObjectMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractLongObjectMap.java
+++ b/src/cern/colt/map/AbstractLongObjectMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/AbstractMap.java
+++ b/src/cern/colt/map/AbstractMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/Benchmark.java
+++ b/src/cern/colt/map/Benchmark.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/HashFunctions.java
+++ b/src/cern/colt/map/HashFunctions.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenDoubleIntHashMap.java
+++ b/src/cern/colt/map/OpenDoubleIntHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenDoubleIntHashMap.java
+++ b/src/cern/colt/map/OpenDoubleIntHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenIntDoubleHashMap.java
+++ b/src/cern/colt/map/OpenIntDoubleHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenIntDoubleHashMap.java
+++ b/src/cern/colt/map/OpenIntDoubleHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenIntIntHashMap.java
+++ b/src/cern/colt/map/OpenIntIntHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenIntIntHashMap.java
+++ b/src/cern/colt/map/OpenIntIntHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenIntObjectHashMap.java
+++ b/src/cern/colt/map/OpenIntObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenIntObjectHashMap.java
+++ b/src/cern/colt/map/OpenIntObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenLongObjectHashMap.java
+++ b/src/cern/colt/map/OpenLongObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/OpenLongObjectHashMap.java
+++ b/src/cern/colt/map/OpenLongObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/QuickOpenIntIntHashMap.java
+++ b/src/cern/colt/map/QuickOpenIntIntHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/map/QuickOpenIntIntHashMap.java
+++ b/src/cern/colt/map/QuickOpenIntIntHashMap.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleFactory1D.java
+++ b/src/cern/colt/matrix/DoubleFactory1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleFactory1D.java
+++ b/src/cern/colt/matrix/DoubleFactory1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleFactory2D.java
+++ b/src/cern/colt/matrix/DoubleFactory2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleFactory2D.java
+++ b/src/cern/colt/matrix/DoubleFactory2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleFactory2D.java
+++ b/src/cern/colt/matrix/DoubleFactory2D.java
@@ -562,12 +562,12 @@ System.out.println("\n"+compose(parts3));
 
 DoubleMatrix2D A = ascending(2,2);
 DoubleMatrix2D B = descending(2,2);
-DoubleMatrix2D _ = null;
+DoubleMatrix2D X = null;
 
 DoubleMatrix2D[][] parts4 = 
 {
-	{ A, _, A, _ },
-	{ _, A, _, B }
+	{ A, X, A, X },
+	{ X, A, X, B }
 };
 System.out.println("\n"+compose(parts4));
 //System.out.println("\n"+cern.colt.matrixpattern.Converting.toHTML(make(parts4).toString()));
@@ -580,13 +580,13 @@ public void demo2() {
 System.out.println("\n\n");
 DoubleMatrix2D matrix;
 DoubleMatrix2D A,B,C,D,E,F,G;
-DoubleMatrix2D _ = null;
+DoubleMatrix2D X = null;
 A = make(2,2,1); B = make (4,4,2); C = make(4,3,3); D = make (2,2,4);
 DoubleMatrix2D[][] parts1 = 
 {
-	{ _, A, _ },
-	{ B, _, C },
-	{ _, D, _ }
+	{ X, A, X },
+	{ B, X, C },
+	{ X, D, X }
 };
 matrix = compose(parts1);
 System.out.println("\n"+matrix);

--- a/src/cern/colt/matrix/DoubleFactory3D.java
+++ b/src/cern/colt/matrix/DoubleFactory3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleFactory3D.java
+++ b/src/cern/colt/matrix/DoubleFactory3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix1D.java
+++ b/src/cern/colt/matrix/DoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix1D.java
+++ b/src/cern/colt/matrix/DoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix1DProcedure.java
+++ b/src/cern/colt/matrix/DoubleMatrix1DProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix2D.java
+++ b/src/cern/colt/matrix/DoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix2D.java
+++ b/src/cern/colt/matrix/DoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix2DProcedure.java
+++ b/src/cern/colt/matrix/DoubleMatrix2DProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix3D.java
+++ b/src/cern/colt/matrix/DoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix3D.java
+++ b/src/cern/colt/matrix/DoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/DoubleMatrix3DProcedure.java
+++ b/src/cern/colt/matrix/DoubleMatrix3DProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectFactory1D.java
+++ b/src/cern/colt/matrix/ObjectFactory1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectFactory1D.java
+++ b/src/cern/colt/matrix/ObjectFactory1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectFactory2D.java
+++ b/src/cern/colt/matrix/ObjectFactory2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectFactory2D.java
+++ b/src/cern/colt/matrix/ObjectFactory2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectFactory3D.java
+++ b/src/cern/colt/matrix/ObjectFactory3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectFactory3D.java
+++ b/src/cern/colt/matrix/ObjectFactory3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix1D.java
+++ b/src/cern/colt/matrix/ObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix1D.java
+++ b/src/cern/colt/matrix/ObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix1DProcedure.java
+++ b/src/cern/colt/matrix/ObjectMatrix1DProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix2D.java
+++ b/src/cern/colt/matrix/ObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix2D.java
+++ b/src/cern/colt/matrix/ObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix2DProcedure.java
+++ b/src/cern/colt/matrix/ObjectMatrix2DProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix3D.java
+++ b/src/cern/colt/matrix/ObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix3D.java
+++ b/src/cern/colt/matrix/ObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/ObjectMatrix3DProcedure.java
+++ b/src/cern/colt/matrix/ObjectMatrix3DProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/bench/Double2DProcedure.java
+++ b/src/cern/colt/matrix/bench/Double2DProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/bench/TimerProcedure.java
+++ b/src/cern/colt/matrix/bench/TimerProcedure.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/DoubleMatrix1DComparator.java
+++ b/src/cern/colt/matrix/doublealgo/DoubleMatrix1DComparator.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/DoubleMatrix1DComparator.java
+++ b/src/cern/colt/matrix/doublealgo/DoubleMatrix1DComparator.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/DoubleMatrix2DComparator.java
+++ b/src/cern/colt/matrix/doublealgo/DoubleMatrix2DComparator.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/DoubleMatrix2DComparator.java
+++ b/src/cern/colt/matrix/doublealgo/DoubleMatrix2DComparator.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Formatter.java
+++ b/src/cern/colt/matrix/doublealgo/Formatter.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Formatter.java
+++ b/src/cern/colt/matrix/doublealgo/Formatter.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Partitioning.java
+++ b/src/cern/colt/matrix/doublealgo/Partitioning.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Partitioning.java
+++ b/src/cern/colt/matrix/doublealgo/Partitioning.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Sorting.java
+++ b/src/cern/colt/matrix/doublealgo/Sorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Sorting.java
+++ b/src/cern/colt/matrix/doublealgo/Sorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Statistic.java
+++ b/src/cern/colt/matrix/doublealgo/Statistic.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Statistic.java
+++ b/src/cern/colt/matrix/doublealgo/Statistic.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Stencil.java
+++ b/src/cern/colt/matrix/doublealgo/Stencil.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Stencil.java
+++ b/src/cern/colt/matrix/doublealgo/Stencil.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/doublealgo/Transform.java
+++ b/src/cern/colt/matrix/doublealgo/Transform.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/AbstractFormatter.java
+++ b/src/cern/colt/matrix/impl/AbstractFormatter.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/AbstractFormatter.java
+++ b/src/cern/colt/matrix/impl/AbstractFormatter.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/AbstractMatrix.java
+++ b/src/cern/colt/matrix/impl/AbstractMatrix.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/AbstractMatrix1D.java
+++ b/src/cern/colt/matrix/impl/AbstractMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/AbstractMatrix2D.java
+++ b/src/cern/colt/matrix/impl/AbstractMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/AbstractMatrix3D.java
+++ b/src/cern/colt/matrix/impl/AbstractMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/Benchmark.java
+++ b/src/cern/colt/matrix/impl/Benchmark.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/Benchmark.java
+++ b/src/cern/colt/matrix/impl/Benchmark.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/BenchmarkMatrix2D.java
+++ b/src/cern/colt/matrix/impl/BenchmarkMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/BenchmarkMatrix2D.java
+++ b/src/cern/colt/matrix/impl/BenchmarkMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DelegateDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/DelegateDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DelegateDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/DelegateDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/DenseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/DenseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/DenseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/DenseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/DenseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/DenseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/DenseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/DenseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/DenseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/DenseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/DenseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/DenseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/DenseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/Former.java
+++ b/src/cern/colt/matrix/impl/Former.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/RCDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/RCDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/RCDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/RCDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/RCMDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/RCMDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/RCMDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/RCMDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedDenseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SelectedSparseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SparseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SparseDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SparseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SparseDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SparseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseDoubleMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SparseDoubleMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SparseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseObjectMatrix1D.java
+++ b/src/cern/colt/matrix/impl/SparseObjectMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SparseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseObjectMatrix2D.java
+++ b/src/cern/colt/matrix/impl/SparseObjectMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SparseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/SparseObjectMatrix3D.java
+++ b/src/cern/colt/matrix/impl/SparseObjectMatrix3D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/TestMatrix2D.java
+++ b/src/cern/colt/matrix/impl/TestMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/TestMatrix2D.java
+++ b/src/cern/colt/matrix/impl/TestMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/TridiagonalDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/TridiagonalDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/TridiagonalDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/TridiagonalDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/WrapperDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/WrapperDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/WrapperDoubleMatrix1D.java
+++ b/src/cern/colt/matrix/impl/WrapperDoubleMatrix1D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/WrapperDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/WrapperDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/impl/WrapperDoubleMatrix2D.java
+++ b/src/cern/colt/matrix/impl/WrapperDoubleMatrix2D.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Algebra.java
+++ b/src/cern/colt/matrix/linalg/Algebra.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Algebra.java
+++ b/src/cern/colt/matrix/linalg/Algebra.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Blas.java
+++ b/src/cern/colt/matrix/linalg/Blas.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Blas.java
+++ b/src/cern/colt/matrix/linalg/Blas.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/CholeskyDecomposition.java
+++ b/src/cern/colt/matrix/linalg/CholeskyDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/CholeskyDecomposition.java
+++ b/src/cern/colt/matrix/linalg/CholeskyDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Diagonal.java
+++ b/src/cern/colt/matrix/linalg/Diagonal.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Diagonal.java
+++ b/src/cern/colt/matrix/linalg/Diagonal.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/EigenvalueDecomposition.java
+++ b/src/cern/colt/matrix/linalg/EigenvalueDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/EigenvalueDecomposition.java
+++ b/src/cern/colt/matrix/linalg/EigenvalueDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/LUDecomposition.java
+++ b/src/cern/colt/matrix/linalg/LUDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/LUDecomposition.java
+++ b/src/cern/colt/matrix/linalg/LUDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/LUDecompositionQuick.java
+++ b/src/cern/colt/matrix/linalg/LUDecompositionQuick.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Matrix2DMatrix2DFunction.java
+++ b/src/cern/colt/matrix/linalg/Matrix2DMatrix2DFunction.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/Property.java
+++ b/src/cern/colt/matrix/linalg/Property.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/QRDecomposition.java
+++ b/src/cern/colt/matrix/linalg/QRDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/QRDecomposition.java
+++ b/src/cern/colt/matrix/linalg/QRDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/SeqBlas.java
+++ b/src/cern/colt/matrix/linalg/SeqBlas.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/SeqBlas.java
+++ b/src/cern/colt/matrix/linalg/SeqBlas.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/SingularValueDecomposition.java
+++ b/src/cern/colt/matrix/linalg/SingularValueDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/linalg/SingularValueDecomposition.java
+++ b/src/cern/colt/matrix/linalg/SingularValueDecomposition.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/Formatter.java
+++ b/src/cern/colt/matrix/objectalgo/Formatter.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/Formatter.java
+++ b/src/cern/colt/matrix/objectalgo/Formatter.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/ObjectMatrix1DComparator.java
+++ b/src/cern/colt/matrix/objectalgo/ObjectMatrix1DComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/ObjectMatrix1DComparator.java
+++ b/src/cern/colt/matrix/objectalgo/ObjectMatrix1DComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/ObjectMatrix2DComparator.java
+++ b/src/cern/colt/matrix/objectalgo/ObjectMatrix2DComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/ObjectMatrix2DComparator.java
+++ b/src/cern/colt/matrix/objectalgo/ObjectMatrix2DComparator.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/Partitioning.java
+++ b/src/cern/colt/matrix/objectalgo/Partitioning.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/Partitioning.java
+++ b/src/cern/colt/matrix/objectalgo/Partitioning.java
@@ -1,7 +1,7 @@
 package cern.colt.matrix.objectalgo;
 
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/Sorting.java
+++ b/src/cern/colt/matrix/objectalgo/Sorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/colt/matrix/objectalgo/Sorting.java
+++ b/src/cern/colt/matrix/objectalgo/Sorting.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Algebraic.java
+++ b/src/cern/jet/math/Algebraic.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Arithmetic.java
+++ b/src/cern/jet/math/Arithmetic.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Bessel.java
+++ b/src/cern/jet/math/Bessel.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Complex.java
+++ b/src/cern/jet/math/Complex.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Constants.java
+++ b/src/cern/jet/math/Constants.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Elliptic.java
+++ b/src/cern/jet/math/Elliptic.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Exponential.java
+++ b/src/cern/jet/math/Exponential.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/ExponentialIntegral.java
+++ b/src/cern/jet/math/ExponentialIntegral.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Functions.java
+++ b/src/cern/jet/math/Functions.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Functions.java
+++ b/src/cern/jet/math/Functions.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/IntFunctions.java
+++ b/src/cern/jet/math/IntFunctions.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/IntFunctions.java
+++ b/src/cern/jet/math/IntFunctions.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Misc.java
+++ b/src/cern/jet/math/Misc.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Mult.java
+++ b/src/cern/jet/math/Mult.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/NumericalIntegration.java
+++ b/src/cern/jet/math/NumericalIntegration.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/PlusMult.java
+++ b/src/cern/jet/math/PlusMult.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/math/Polynomial.java
+++ b/src/cern/jet/math/Polynomial.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/AbstractContinousDistribution.java
+++ b/src/cern/jet/random/AbstractContinousDistribution.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/AbstractDiscreteDistribution.java
+++ b/src/cern/jet/random/AbstractDiscreteDistribution.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/AbstractDistribution.java
+++ b/src/cern/jet/random/AbstractDistribution.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/AbstractDistribution.java
+++ b/src/cern/jet/random/AbstractDistribution.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Benchmark.java
+++ b/src/cern/jet/random/Benchmark.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Benchmark.java
+++ b/src/cern/jet/random/Benchmark.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Beta.java
+++ b/src/cern/jet/random/Beta.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Beta.java
+++ b/src/cern/jet/random/Beta.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Binomial.java
+++ b/src/cern/jet/random/Binomial.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Binomial.java
+++ b/src/cern/jet/random/Binomial.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/BreitWigner.java
+++ b/src/cern/jet/random/BreitWigner.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/BreitWigner.java
+++ b/src/cern/jet/random/BreitWigner.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/BreitWignerMeanSquare.java
+++ b/src/cern/jet/random/BreitWignerMeanSquare.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/BreitWignerMeanSquare.java
+++ b/src/cern/jet/random/BreitWignerMeanSquare.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/ChiSquare.java
+++ b/src/cern/jet/random/ChiSquare.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/ChiSquare.java
+++ b/src/cern/jet/random/ChiSquare.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Distributions.java
+++ b/src/cern/jet/random/Distributions.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Distributions.java
+++ b/src/cern/jet/random/Distributions.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Empirical.java
+++ b/src/cern/jet/random/Empirical.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Empirical.java
+++ b/src/cern/jet/random/Empirical.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/EmpiricalWalker.java
+++ b/src/cern/jet/random/EmpiricalWalker.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/EmpiricalWalker.java
+++ b/src/cern/jet/random/EmpiricalWalker.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Exponential.java
+++ b/src/cern/jet/random/Exponential.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Exponential.java
+++ b/src/cern/jet/random/Exponential.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/ExponentialPower.java
+++ b/src/cern/jet/random/ExponentialPower.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/ExponentialPower.java
+++ b/src/cern/jet/random/ExponentialPower.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Fun.java
+++ b/src/cern/jet/random/Fun.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Fun.java
+++ b/src/cern/jet/random/Fun.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Gamma.java
+++ b/src/cern/jet/random/Gamma.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Gamma.java
+++ b/src/cern/jet/random/Gamma.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/HyperGeometric.java
+++ b/src/cern/jet/random/HyperGeometric.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/HyperGeometric.java
+++ b/src/cern/jet/random/HyperGeometric.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Hyperbolic.java
+++ b/src/cern/jet/random/Hyperbolic.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Hyperbolic.java
+++ b/src/cern/jet/random/Hyperbolic.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Logarithmic.java
+++ b/src/cern/jet/random/Logarithmic.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Logarithmic.java
+++ b/src/cern/jet/random/Logarithmic.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/NegativeBinomial.java
+++ b/src/cern/jet/random/NegativeBinomial.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/NegativeBinomial.java
+++ b/src/cern/jet/random/NegativeBinomial.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Normal.java
+++ b/src/cern/jet/random/Normal.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Normal.java
+++ b/src/cern/jet/random/Normal.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Poisson.java
+++ b/src/cern/jet/random/Poisson.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Poisson.java
+++ b/src/cern/jet/random/Poisson.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/PoissonSlow.java
+++ b/src/cern/jet/random/PoissonSlow.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/PoissonSlow.java
+++ b/src/cern/jet/random/PoissonSlow.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Stack.java
+++ b/src/cern/jet/random/Stack.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/StudentT.java
+++ b/src/cern/jet/random/StudentT.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/StudentT.java
+++ b/src/cern/jet/random/StudentT.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Uniform.java
+++ b/src/cern/jet/random/Uniform.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Uniform.java
+++ b/src/cern/jet/random/Uniform.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/VonMises.java
+++ b/src/cern/jet/random/VonMises.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/VonMises.java
+++ b/src/cern/jet/random/VonMises.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Zeta.java
+++ b/src/cern/jet/random/Zeta.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/Zeta.java
+++ b/src/cern/jet/random/Zeta.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/Benchmark.java
+++ b/src/cern/jet/random/engine/Benchmark.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/Benchmark.java
+++ b/src/cern/jet/random/engine/Benchmark.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/DRand.java
+++ b/src/cern/jet/random/engine/DRand.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/DRand.java
+++ b/src/cern/jet/random/engine/DRand.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/MersenneTwister.java
+++ b/src/cern/jet/random/engine/MersenneTwister.java
@@ -1,7 +1,7 @@
 package cern.jet.random.engine;
 
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/MersenneTwister.java
+++ b/src/cern/jet/random/engine/MersenneTwister.java
@@ -1,7 +1,7 @@
 package cern.jet.random.engine;
 
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/MersenneTwister64.java
+++ b/src/cern/jet/random/engine/MersenneTwister64.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/MersenneTwister64.java
+++ b/src/cern/jet/random/engine/MersenneTwister64.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/RandomEngine.java
+++ b/src/cern/jet/random/engine/RandomEngine.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/RandomEngine.java
+++ b/src/cern/jet/random/engine/RandomEngine.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/RandomGenerator.java
+++ b/src/cern/jet/random/engine/RandomGenerator.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/RandomGenerator.java
+++ b/src/cern/jet/random/engine/RandomGenerator.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/RandomSeedGenerator.java
+++ b/src/cern/jet/random/engine/RandomSeedGenerator.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/engine/RandomSeedTable.java
+++ b/src/cern/jet/random/engine/RandomSeedTable.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/sampling/RandomSampler.java
+++ b/src/cern/jet/random/sampling/RandomSampler.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/sampling/RandomSampler.java
+++ b/src/cern/jet/random/sampling/RandomSampler.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/sampling/RandomSamplingAssistant.java
+++ b/src/cern/jet/random/sampling/RandomSamplingAssistant.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/sampling/RandomSamplingAssistant.java
+++ b/src/cern/jet/random/sampling/RandomSamplingAssistant.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/sampling/WeightedRandomSampler.java
+++ b/src/cern/jet/random/sampling/WeightedRandomSampler.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/random/sampling/WeightedRandomSampler.java
+++ b/src/cern/jet/random/sampling/WeightedRandomSampler.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/Descriptive.java
+++ b/src/cern/jet/stat/Descriptive.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/Descriptive.java
+++ b/src/cern/jet/stat/Descriptive.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/Gamma.java
+++ b/src/cern/jet/stat/Gamma.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/Probability.java
+++ b/src/cern/jet/stat/Probability.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/Buffer.java
+++ b/src/cern/jet/stat/quantile/Buffer.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/BufferSet.java
+++ b/src/cern/jet/stat/quantile/BufferSet.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/DoubleBuffer.java
+++ b/src/cern/jet/stat/quantile/DoubleBuffer.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/DoubleBuffer.java
+++ b/src/cern/jet/stat/quantile/DoubleBuffer.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/DoubleBufferSet.java
+++ b/src/cern/jet/stat/quantile/DoubleBufferSet.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/DoubleQuantileEstimator.java
+++ b/src/cern/jet/stat/quantile/DoubleQuantileEstimator.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/DoubleQuantileEstimator.java
+++ b/src/cern/jet/stat/quantile/DoubleQuantileEstimator.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/DoubleQuantileFinder.java
+++ b/src/cern/jet/stat/quantile/DoubleQuantileFinder.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/EquiDepthHistogram.java
+++ b/src/cern/jet/stat/quantile/EquiDepthHistogram.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/EquiDepthHistogram.java
+++ b/src/cern/jet/stat/quantile/EquiDepthHistogram.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/ExactDoubleQuantileFinder.java
+++ b/src/cern/jet/stat/quantile/ExactDoubleQuantileFinder.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/ExactDoubleQuantileFinder.java
+++ b/src/cern/jet/stat/quantile/ExactDoubleQuantileFinder.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/KnownDoubleQuantileEstimator.java
+++ b/src/cern/jet/stat/quantile/KnownDoubleQuantileEstimator.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/KnownDoubleQuantileEstimator.java
+++ b/src/cern/jet/stat/quantile/KnownDoubleQuantileEstimator.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/QuantileCalc.java
+++ b/src/cern/jet/stat/quantile/QuantileCalc.java
@@ -1,5 +1,5 @@
 /*
-Copyright © 1999 CERN - European Organization for Nuclear Research.
+Copyright Â© 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/QuantileFinderFactory.java
+++ b/src/cern/jet/stat/quantile/QuantileFinderFactory.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/QuantileFinderFactory.java
+++ b/src/cern/jet/stat/quantile/QuantileFinderFactory.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/QuantileFinderTest.java
+++ b/src/cern/jet/stat/quantile/QuantileFinderTest.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/QuantileFinderTest.java
+++ b/src/cern/jet/stat/quantile/QuantileFinderTest.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/UnknownDoubleQuantileEstimator.java
+++ b/src/cern/jet/stat/quantile/UnknownDoubleQuantileEstimator.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/UnknownDoubleQuantileEstimator.java
+++ b/src/cern/jet/stat/quantile/UnknownDoubleQuantileEstimator.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/Utils.java
+++ b/src/cern/jet/stat/quantile/Utils.java
@@ -1,5 +1,5 @@
 /*
-Copyright � 1999 CERN - European Organization for Nuclear Research.
+Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/cern/jet/stat/quantile/Utils.java
+++ b/src/cern/jet/stat/quantile/Utils.java
@@ -1,5 +1,5 @@
 /*
-Copyright ï¿½ 1999 CERN - European Organization for Nuclear Research.
+Copyright © 1999 CERN - European Organization for Nuclear Research.
 Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
 is hereby granted without fee, provided that the above copyright notice appear in all copies and 
 that both that copyright notice and this permission notice appear in supporting documentation. 


### PR DESCRIPTION
Some of the files in the CERN Colt library were encoded as ISO-8559-1, so I ran `iconv` to convert them to UTF-8.
This left some strange artifacts, which I fixed.
In addition, I removed use of the "_" identifier, which is disallowed in Java 9 and newer.